### PR TITLE
Rename model parameters in wrapper classes

### DIFF
--- a/src/ontime/core/modelling/libs/darts/darts_forecasting_model.py
+++ b/src/ontime/core/modelling/libs/darts/darts_forecasting_model.py
@@ -10,17 +10,17 @@ class DartsForecastingModel(AbstractModel):
     Generic wrapper around Darts forecasting models
     """
 
-    def __init__(self, model: Union[Type[ModelMeta], ModelMeta], **params):
+    def __init__(self, darts_model: Union[Type[ModelMeta], ModelMeta], **params):
         """Constructor of a ForecastingModel object
 
-        :param model: Darts forecasting model class
+        :param darts_model: Darts forecasting model class
         :param params: dict of keyword arguments for this model's constructor
         """
         super().__init__()
-        self.model = model
+        self.model = darts_model
         # check if model is a class or an instance
-        if isinstance(model, type):
-            self.model = model(**params)
+        if isinstance(darts_model, type):
+            self.model = darts_model(**params)
 
     def fit(self, ts: TimeSeries, **params) -> "DartsForecastingModel":
         self.model.fit(ts, **params)

--- a/src/ontime/core/modelling/libs/pytorch/pytorch_forecasting_model.py
+++ b/src/ontime/core/modelling/libs/pytorch/pytorch_forecasting_model.py
@@ -20,7 +20,7 @@ class TorchForecastingModel(L.LightningModule, AbstractModel):
 
     def __init__(
         self,
-        model: Union[Type[nn.Module], nn.Module],
+        torch_model: Union[Type[nn.Module], nn.Module],
         input_chunk_length: int,
         output_chunk_length: int,
         n_epochs: int = 10,
@@ -31,7 +31,7 @@ class TorchForecastingModel(L.LightningModule, AbstractModel):
     ):
         """Constructor of a TorchForecastingModel object
 
-        :param model: a torch model class (not instantiated)
+        :param torch_model: a torch model class (not instantiated)
         :param input_chunk_length: number of time steps in the past the model use for making one predicton
         :param output_chunk_length: number of time steps to be predicted by the model at once
         :param n_epochs: number of training epochs
@@ -40,10 +40,10 @@ class TorchForecastingModel(L.LightningModule, AbstractModel):
         :param train_data_module_params: params for the training data module to use. Input length and target length are defined by input_chunk_length and output_chunk_length parameters
         """
         super(TorchForecastingModel, self).__init__()
-        self.model = model
+        self.model = torch_model
         # check if model is a class or an instance
-        if isinstance(model, type):
-            self.model = model(**params)
+        if isinstance(torch_model, type):
+            self.model = torch_model(**params)
         self.input_chunk_length = input_chunk_length
         self.output_chunk_length = output_chunk_length
         self.n_epochs = n_epochs

--- a/src/ontime/core/modelling/libs/skforecast/forecaster_autoreg.py
+++ b/src/ontime/core/modelling/libs/skforecast/forecaster_autoreg.py
@@ -13,15 +13,15 @@ class ForecasterAutoreg(AbstractModel):
     Generic wrapper around SkForecast ForecasterAutoreg models
     """
 
-    def __init__(self, model: Union[Type[BaseEstimator], BaseEstimator], **params):
+    def __init__(self, sk_model: Union[Type[BaseEstimator], BaseEstimator], **params):
         """
         Initialize model based on ForecasterAutoreg. **params are defined in ForecasterAutoreg from sklearn
         """
         super().__init__()
         # check if model is a class or an instance
-        if isinstance(model, type):
-            model = model()
-        self.model = SkForecastForecasterAutoreg(regressor=model, **params)
+        if isinstance(sk_model, type):
+            sk_model = sk_model()
+        self.model = SkForecastForecasterAutoreg(regressor=sk_model, **params)
 
     def fit(self, ts: TimeSeries, **params) -> "ForecasterAutoreg":
         self.model.fit(y=ts.pd_series(), **params)

--- a/src/ontime/core/modelling/libs/skforecast/forecaster_autoreg_multi_variate.py
+++ b/src/ontime/core/modelling/libs/skforecast/forecaster_autoreg_multi_variate.py
@@ -13,16 +13,16 @@ class ForecasterAutoregMultiVariate(AbstractModel):
     Generic wrapper around SkForecast ForecasterAutoreg models
     """
 
-    def __init__(self, model: Union[Type[BaseEstimator], BaseEstimator], **params):
+    def __init__(self, sk_model: Union[Type[BaseEstimator], BaseEstimator], **params):
         """
         Initialize model based on ForecasterAutoregMultiVariate. **params are defined in ForecasterAutoregMultiVariate
         from sklearn
         """
         super().__init__()
         # check if model is a class or an instance
-        if isinstance(model, type):
-            model = model()
-        self.model = SkForecasterAutoregMultiVariate(regressor=model, **params)
+        if isinstance(sk_model, type):
+            sk_model = sk_model()
+        self.model = SkForecasterAutoregMultiVariate(regressor=sk_model, **params)
 
     def fit(self, ts: TimeSeries, **params) -> "ForecasterAutoregMultiVariate":
         self.model.fit(series=ts.pd_dataframe(), **params)

--- a/src/ontime/core/modelling/model.py
+++ b/src/ontime/core/modelling/model.py
@@ -42,15 +42,17 @@ class Model(AbstractModel):
     It is chosen once and then kept for the whole lifecycle of the model.
     """
 
-    def __init__(self, model: Union[AbstractModel, Type[AbstractModel]], **params):
+    def __init__(
+        self, wrapped_model: Union[AbstractModel, Type[AbstractModel]], **params
+    ):
         """
         Initializes a Model.
 
-        :param model: either a model class or a model instance
+        :param wrapped_model: either a model class or a model instance
         """
 
         super().__init__()
-        self.model = model
+        self.model = wrapped_model
         self.params = params
         self.is_model_undefined = True
 
@@ -81,6 +83,8 @@ class Model(AbstractModel):
         """
 
         size_of_ts = ts.n_components
+
+        # handle naming conflict:
 
         if is_subclass_or_instance_of_subclass(self.model, ForecastingModel):
             # Darts Models


### PR DESCRIPTION
Rename model parameters in wrapper classes, avoiding potential conflict with wrapped model parameter name (such as darts BlockRNN that has a model parameter)